### PR TITLE
added CI sync script and Dockerfiles

### DIFF
--- a/ci/hydro-precise-shadow-fixed/Dockerfile
+++ b/ci/hydro-precise-shadow-fixed/Dockerfile
@@ -1,3 +1,6 @@
+# DO NOT EDIT!
+# This file  was auto-generated with ./sync.sh at Fri May 12 16:50:41 CEST 2017
+
 FROM ubuntu:precise
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections

--- a/ci/hydro-precise-shadow-fixed/Dockerfile
+++ b/ci/hydro-precise-shadow-fixed/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:precise
+
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
+RUN apt-get update -qq     && apt-get -qq install --no-install-recommends -y apt-utils gnupg wget ca-certificates sudo
+
+RUN echo "deb http://packages.ros.org/ros/ubuntu precise main" > /etc/apt/sources.list.d/ros-latest.list
+RUN apt-key adv --keyserver "hkp://ha.pool.sks-keyservers.net" --recv-key "0xB01FA116"     || { wget "https://raw.githubusercontent.com/ros/rosdistro/master/ros.key" -O - | sudo apt-key add -; }
+
+RUN sed -i "/^# deb.*multiverse/ s/^# //" /etc/apt/sources.list     && apt-get update -qq     && apt-get -qq install --no-install-recommends -y         build-essential         python-catkin-tools         python-pip         python-rosdep         python-wstool         ros-hydro-catkin         ssh-client     && apt-get clean     && rm -rf /var/lib/apt/lists/*

--- a/ci/hydro-precise-shadow-fixed/Dockerfile
+++ b/ci/hydro-precise-shadow-fixed/Dockerfile
@@ -1,7 +1,8 @@
 # DO NOT EDIT!
-# This file  was auto-generated with ./sync.sh at Fri May 12 16:50:41 CEST 2017
+# This file  was auto-generated with ./sync.sh at Fri May 12 17:02:13 CEST 2017
 
 FROM ubuntu:precise
+LABEL MAINTAINER "Mathias Lüdtke" <mathias.luedtke@ipa.fraunhofer.de>
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 

--- a/ci/hydro-precise/Dockerfile
+++ b/ci/hydro-precise/Dockerfile
@@ -1,3 +1,6 @@
+# DO NOT EDIT!
+# This file  was auto-generated with ./sync.sh at Fri May 12 16:50:41 CEST 2017
+
 FROM ubuntu:precise
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections

--- a/ci/hydro-precise/Dockerfile
+++ b/ci/hydro-precise/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:precise
+
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
+RUN apt-get update -qq     && apt-get -qq install --no-install-recommends -y apt-utils gnupg wget ca-certificates sudo
+
+RUN echo "deb http://packages.ros.org/ros/ubuntu precise main" > /etc/apt/sources.list.d/ros-latest.list
+RUN apt-key adv --keyserver "hkp://ha.pool.sks-keyservers.net" --recv-key "0xB01FA116"     || { wget "https://raw.githubusercontent.com/ros/rosdistro/master/ros.key" -O - | sudo apt-key add -; }
+
+RUN sed -i "/^# deb.*multiverse/ s/^# //" /etc/apt/sources.list     && apt-get update -qq     && apt-get -qq install --no-install-recommends -y         build-essential         python-catkin-tools         python-pip         python-rosdep         python-wstool         ros-hydro-catkin         ssh-client     && apt-get clean     && rm -rf /var/lib/apt/lists/*

--- a/ci/hydro-precise/Dockerfile
+++ b/ci/hydro-precise/Dockerfile
@@ -1,7 +1,8 @@
 # DO NOT EDIT!
-# This file  was auto-generated with ./sync.sh at Fri May 12 16:50:41 CEST 2017
+# This file  was auto-generated with ./sync.sh at Fri May 12 17:02:13 CEST 2017
 
 FROM ubuntu:precise
+LABEL MAINTAINER "Mathias Lüdtke" <mathias.luedtke@ipa.fraunhofer.de>
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 

--- a/ci/indigo-trusty-shadow-fixed/Dockerfile
+++ b/ci/indigo-trusty-shadow-fixed/Dockerfile
@@ -1,7 +1,8 @@
 # DO NOT EDIT!
-# This file  was auto-generated with ./sync.sh at Fri May 12 16:50:41 CEST 2017
+# This file  was auto-generated with ./sync.sh at Fri May 12 17:02:13 CEST 2017
 
 FROM ubuntu:trusty
+LABEL MAINTAINER "Mathias Lüdtke" <mathias.luedtke@ipa.fraunhofer.de>
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 

--- a/ci/indigo-trusty-shadow-fixed/Dockerfile
+++ b/ci/indigo-trusty-shadow-fixed/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:trusty
+
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
+RUN apt-get update -qq     && apt-get -qq install --no-install-recommends -y apt-utils gnupg wget ca-certificates sudo
+
+RUN echo "deb http://packages.ros.org/ros/ubuntu trusty main" > /etc/apt/sources.list.d/ros-latest.list
+RUN apt-key adv --keyserver "hkp://ha.pool.sks-keyservers.net" --recv-key "0xB01FA116"     || { wget "https://raw.githubusercontent.com/ros/rosdistro/master/ros.key" -O - | sudo apt-key add -; }
+
+RUN sed -i "/^# deb.*multiverse/ s/^# //" /etc/apt/sources.list     && apt-get update -qq     && apt-get -qq install --no-install-recommends -y         build-essential         python-catkin-tools         python-pip         python-rosdep         python-wstool         ros-indigo-catkin         ssh-client     && apt-get clean     && rm -rf /var/lib/apt/lists/*

--- a/ci/indigo-trusty-shadow-fixed/Dockerfile
+++ b/ci/indigo-trusty-shadow-fixed/Dockerfile
@@ -1,3 +1,6 @@
+# DO NOT EDIT!
+# This file  was auto-generated with ./sync.sh at Fri May 12 16:50:41 CEST 2017
+
 FROM ubuntu:trusty
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections

--- a/ci/indigo-trusty/Dockerfile
+++ b/ci/indigo-trusty/Dockerfile
@@ -1,7 +1,8 @@
 # DO NOT EDIT!
-# This file  was auto-generated with ./sync.sh at Fri May 12 16:50:41 CEST 2017
+# This file  was auto-generated with ./sync.sh at Fri May 12 17:02:13 CEST 2017
 
 FROM ubuntu:trusty
+LABEL MAINTAINER "Mathias Lüdtke" <mathias.luedtke@ipa.fraunhofer.de>
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 

--- a/ci/indigo-trusty/Dockerfile
+++ b/ci/indigo-trusty/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:trusty
+
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
+RUN apt-get update -qq     && apt-get -qq install --no-install-recommends -y apt-utils gnupg wget ca-certificates sudo
+
+RUN echo "deb http://packages.ros.org/ros/ubuntu trusty main" > /etc/apt/sources.list.d/ros-latest.list
+RUN apt-key adv --keyserver "hkp://ha.pool.sks-keyservers.net" --recv-key "0xB01FA116"     || { wget "https://raw.githubusercontent.com/ros/rosdistro/master/ros.key" -O - | sudo apt-key add -; }
+
+RUN sed -i "/^# deb.*multiverse/ s/^# //" /etc/apt/sources.list     && apt-get update -qq     && apt-get -qq install --no-install-recommends -y         build-essential         python-catkin-tools         python-pip         python-rosdep         python-wstool         ros-indigo-catkin         ssh-client     && apt-get clean     && rm -rf /var/lib/apt/lists/*

--- a/ci/indigo-trusty/Dockerfile
+++ b/ci/indigo-trusty/Dockerfile
@@ -1,3 +1,6 @@
+# DO NOT EDIT!
+# This file  was auto-generated with ./sync.sh at Fri May 12 16:50:41 CEST 2017
+
 FROM ubuntu:trusty
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections

--- a/ci/jade-trusty-shadow-fixed/Dockerfile
+++ b/ci/jade-trusty-shadow-fixed/Dockerfile
@@ -1,7 +1,8 @@
 # DO NOT EDIT!
-# This file  was auto-generated with ./sync.sh at Fri May 12 16:50:41 CEST 2017
+# This file  was auto-generated with ./sync.sh at Fri May 12 17:02:13 CEST 2017
 
 FROM ubuntu:trusty
+LABEL MAINTAINER "Mathias Lüdtke" <mathias.luedtke@ipa.fraunhofer.de>
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 

--- a/ci/jade-trusty-shadow-fixed/Dockerfile
+++ b/ci/jade-trusty-shadow-fixed/Dockerfile
@@ -1,3 +1,6 @@
+# DO NOT EDIT!
+# This file  was auto-generated with ./sync.sh at Fri May 12 16:50:41 CEST 2017
+
 FROM ubuntu:trusty
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections

--- a/ci/jade-trusty-shadow-fixed/Dockerfile
+++ b/ci/jade-trusty-shadow-fixed/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:trusty
+
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
+RUN apt-get update -qq     && apt-get -qq install --no-install-recommends -y apt-utils gnupg wget ca-certificates sudo
+
+RUN echo "deb http://packages.ros.org/ros/ubuntu trusty main" > /etc/apt/sources.list.d/ros-latest.list
+RUN apt-key adv --keyserver "hkp://ha.pool.sks-keyservers.net" --recv-key "0xB01FA116"     || { wget "https://raw.githubusercontent.com/ros/rosdistro/master/ros.key" -O - | sudo apt-key add -; }
+
+RUN sed -i "/^# deb.*multiverse/ s/^# //" /etc/apt/sources.list     && apt-get update -qq     && apt-get -qq install --no-install-recommends -y         build-essential         python-catkin-tools         python-pip         python-rosdep         python-wstool         ros-jade-catkin         ssh-client     && apt-get clean     && rm -rf /var/lib/apt/lists/*

--- a/ci/jade-trusty/Dockerfile
+++ b/ci/jade-trusty/Dockerfile
@@ -1,7 +1,8 @@
 # DO NOT EDIT!
-# This file  was auto-generated with ./sync.sh at Fri May 12 16:50:41 CEST 2017
+# This file  was auto-generated with ./sync.sh at Fri May 12 17:02:13 CEST 2017
 
 FROM ubuntu:trusty
+LABEL MAINTAINER "Mathias Lüdtke" <mathias.luedtke@ipa.fraunhofer.de>
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 

--- a/ci/jade-trusty/Dockerfile
+++ b/ci/jade-trusty/Dockerfile
@@ -1,3 +1,6 @@
+# DO NOT EDIT!
+# This file  was auto-generated with ./sync.sh at Fri May 12 16:50:41 CEST 2017
+
 FROM ubuntu:trusty
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections

--- a/ci/jade-trusty/Dockerfile
+++ b/ci/jade-trusty/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:trusty
+
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
+RUN apt-get update -qq     && apt-get -qq install --no-install-recommends -y apt-utils gnupg wget ca-certificates sudo
+
+RUN echo "deb http://packages.ros.org/ros/ubuntu trusty main" > /etc/apt/sources.list.d/ros-latest.list
+RUN apt-key adv --keyserver "hkp://ha.pool.sks-keyservers.net" --recv-key "0xB01FA116"     || { wget "https://raw.githubusercontent.com/ros/rosdistro/master/ros.key" -O - | sudo apt-key add -; }
+
+RUN sed -i "/^# deb.*multiverse/ s/^# //" /etc/apt/sources.list     && apt-get update -qq     && apt-get -qq install --no-install-recommends -y         build-essential         python-catkin-tools         python-pip         python-rosdep         python-wstool         ros-jade-catkin         ssh-client     && apt-get clean     && rm -rf /var/lib/apt/lists/*

--- a/ci/kinetic-jessie-shadow-fixed/Dockerfile
+++ b/ci/kinetic-jessie-shadow-fixed/Dockerfile
@@ -1,7 +1,8 @@
 # DO NOT EDIT!
-# This file  was auto-generated with ./sync.sh at Fri May 12 16:50:41 CEST 2017
+# This file  was auto-generated with ./sync.sh at Fri May 12 17:02:13 CEST 2017
 
 FROM debian:jessie
+LABEL MAINTAINER "Mathias Lüdtke" <mathias.luedtke@ipa.fraunhofer.de>
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 

--- a/ci/kinetic-jessie-shadow-fixed/Dockerfile
+++ b/ci/kinetic-jessie-shadow-fixed/Dockerfile
@@ -1,3 +1,6 @@
+# DO NOT EDIT!
+# This file  was auto-generated with ./sync.sh at Fri May 12 16:50:41 CEST 2017
+
 FROM debian:jessie
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections

--- a/ci/kinetic-jessie-shadow-fixed/Dockerfile
+++ b/ci/kinetic-jessie-shadow-fixed/Dockerfile
@@ -1,0 +1,10 @@
+FROM debian:jessie
+
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
+RUN apt-get update -qq     && apt-get -qq install --no-install-recommends -y apt-utils gnupg wget ca-certificates sudo
+
+RUN echo "deb http://packages.ros.org/ros/ubuntu jessie main" > /etc/apt/sources.list.d/ros-latest.list
+RUN apt-key adv --keyserver "hkp://ha.pool.sks-keyservers.net" --recv-key "0xB01FA116"     || { wget "https://raw.githubusercontent.com/ros/rosdistro/master/ros.key" -O - | sudo apt-key add -; }
+
+RUN sed -i "/^# deb.*multiverse/ s/^# //" /etc/apt/sources.list     && apt-get update -qq     && apt-get -qq install --no-install-recommends -y         build-essential         python-catkin-tools         python-pip         python-rosdep         python-wstool         ros-kinetic-catkin         ssh-client     && apt-get clean     && rm -rf /var/lib/apt/lists/*

--- a/ci/kinetic-jessie/Dockerfile
+++ b/ci/kinetic-jessie/Dockerfile
@@ -1,7 +1,8 @@
 # DO NOT EDIT!
-# This file  was auto-generated with ./sync.sh at Fri May 12 16:50:41 CEST 2017
+# This file  was auto-generated with ./sync.sh at Fri May 12 17:02:13 CEST 2017
 
 FROM debian:jessie
+LABEL MAINTAINER "Mathias Lüdtke" <mathias.luedtke@ipa.fraunhofer.de>
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 

--- a/ci/kinetic-jessie/Dockerfile
+++ b/ci/kinetic-jessie/Dockerfile
@@ -1,3 +1,6 @@
+# DO NOT EDIT!
+# This file  was auto-generated with ./sync.sh at Fri May 12 16:50:41 CEST 2017
+
 FROM debian:jessie
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections

--- a/ci/kinetic-jessie/Dockerfile
+++ b/ci/kinetic-jessie/Dockerfile
@@ -1,0 +1,10 @@
+FROM debian:jessie
+
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
+RUN apt-get update -qq     && apt-get -qq install --no-install-recommends -y apt-utils gnupg wget ca-certificates sudo
+
+RUN echo "deb http://packages.ros.org/ros/ubuntu jessie main" > /etc/apt/sources.list.d/ros-latest.list
+RUN apt-key adv --keyserver "hkp://ha.pool.sks-keyservers.net" --recv-key "0xB01FA116"     || { wget "https://raw.githubusercontent.com/ros/rosdistro/master/ros.key" -O - | sudo apt-key add -; }
+
+RUN sed -i "/^# deb.*multiverse/ s/^# //" /etc/apt/sources.list     && apt-get update -qq     && apt-get -qq install --no-install-recommends -y         build-essential         python-catkin-tools         python-pip         python-rosdep         python-wstool         ros-kinetic-catkin         ssh-client     && apt-get clean     && rm -rf /var/lib/apt/lists/*

--- a/ci/kinetic-xenial-shadow-fixed/Dockerfile
+++ b/ci/kinetic-xenial-shadow-fixed/Dockerfile
@@ -1,7 +1,8 @@
 # DO NOT EDIT!
-# This file  was auto-generated with ./sync.sh at Fri May 12 16:50:41 CEST 2017
+# This file  was auto-generated with ./sync.sh at Fri May 12 17:02:13 CEST 2017
 
 FROM ubuntu:xenial
+LABEL MAINTAINER "Mathias Lüdtke" <mathias.luedtke@ipa.fraunhofer.de>
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 

--- a/ci/kinetic-xenial-shadow-fixed/Dockerfile
+++ b/ci/kinetic-xenial-shadow-fixed/Dockerfile
@@ -1,3 +1,6 @@
+# DO NOT EDIT!
+# This file  was auto-generated with ./sync.sh at Fri May 12 16:50:41 CEST 2017
+
 FROM ubuntu:xenial
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections

--- a/ci/kinetic-xenial-shadow-fixed/Dockerfile
+++ b/ci/kinetic-xenial-shadow-fixed/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:xenial
+
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
+RUN apt-get update -qq     && apt-get -qq install --no-install-recommends -y apt-utils gnupg wget ca-certificates sudo
+
+RUN echo "deb http://packages.ros.org/ros/ubuntu xenial main" > /etc/apt/sources.list.d/ros-latest.list
+RUN apt-key adv --keyserver "hkp://ha.pool.sks-keyservers.net" --recv-key "0xB01FA116"     || { wget "https://raw.githubusercontent.com/ros/rosdistro/master/ros.key" -O - | sudo apt-key add -; }
+
+RUN sed -i "/^# deb.*multiverse/ s/^# //" /etc/apt/sources.list     && apt-get update -qq     && apt-get -qq install --no-install-recommends -y         build-essential         python-catkin-tools         python-pip         python-rosdep         python-wstool         ros-kinetic-catkin         ssh-client     && apt-get clean     && rm -rf /var/lib/apt/lists/*

--- a/ci/kinetic-xenial/Dockerfile
+++ b/ci/kinetic-xenial/Dockerfile
@@ -1,7 +1,8 @@
 # DO NOT EDIT!
-# This file  was auto-generated with ./sync.sh at Fri May 12 16:50:41 CEST 2017
+# This file  was auto-generated with ./sync.sh at Fri May 12 17:02:13 CEST 2017
 
 FROM ubuntu:xenial
+LABEL MAINTAINER "Mathias Lüdtke" <mathias.luedtke@ipa.fraunhofer.de>
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 

--- a/ci/kinetic-xenial/Dockerfile
+++ b/ci/kinetic-xenial/Dockerfile
@@ -1,3 +1,6 @@
+# DO NOT EDIT!
+# This file  was auto-generated with ./sync.sh at Fri May 12 16:50:41 CEST 2017
+
 FROM ubuntu:xenial
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections

--- a/ci/kinetic-xenial/Dockerfile
+++ b/ci/kinetic-xenial/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:xenial
+
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
+RUN apt-get update -qq     && apt-get -qq install --no-install-recommends -y apt-utils gnupg wget ca-certificates sudo
+
+RUN echo "deb http://packages.ros.org/ros/ubuntu xenial main" > /etc/apt/sources.list.d/ros-latest.list
+RUN apt-key adv --keyserver "hkp://ha.pool.sks-keyservers.net" --recv-key "0xB01FA116"     || { wget "https://raw.githubusercontent.com/ros/rosdistro/master/ros.key" -O - | sudo apt-key add -; }
+
+RUN sed -i "/^# deb.*multiverse/ s/^# //" /etc/apt/sources.list     && apt-get update -qq     && apt-get -qq install --no-install-recommends -y         build-essential         python-catkin-tools         python-pip         python-rosdep         python-wstool         ros-kinetic-catkin         ssh-client     && apt-get clean     && rm -rf /var/lib/apt/lists/*

--- a/ci/lunar-stretch-shadow-fixed/Dockerfile
+++ b/ci/lunar-stretch-shadow-fixed/Dockerfile
@@ -1,0 +1,10 @@
+FROM debian:stretch
+
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
+RUN apt-get update -qq     && apt-get -qq install --no-install-recommends -y apt-utils gnupg wget ca-certificates sudo
+
+RUN echo "deb http://packages.ros.org/ros/ubuntu stretch main" > /etc/apt/sources.list.d/ros-latest.list
+RUN apt-key adv --keyserver "hkp://ha.pool.sks-keyservers.net" --recv-key "0xB01FA116"     || { wget "https://raw.githubusercontent.com/ros/rosdistro/master/ros.key" -O - | sudo apt-key add -; }
+
+RUN sed -i "/^# deb.*multiverse/ s/^# //" /etc/apt/sources.list     && apt-get update -qq     && apt-get -qq install --no-install-recommends -y         build-essential         python-catkin-tools         python-pip         python-rosdep         python-wstool         ros-lunar-catkin         ssh-client     && apt-get clean     && rm -rf /var/lib/apt/lists/*

--- a/ci/lunar-stretch-shadow-fixed/Dockerfile
+++ b/ci/lunar-stretch-shadow-fixed/Dockerfile
@@ -1,3 +1,6 @@
+# DO NOT EDIT!
+# This file  was auto-generated with ./sync.sh at Fri May 12 16:50:41 CEST 2017
+
 FROM debian:stretch
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections

--- a/ci/lunar-stretch-shadow-fixed/Dockerfile
+++ b/ci/lunar-stretch-shadow-fixed/Dockerfile
@@ -1,7 +1,8 @@
 # DO NOT EDIT!
-# This file  was auto-generated with ./sync.sh at Fri May 12 16:50:41 CEST 2017
+# This file  was auto-generated with ./sync.sh at Fri May 12 17:02:13 CEST 2017
 
 FROM debian:stretch
+LABEL MAINTAINER "Mathias Lüdtke" <mathias.luedtke@ipa.fraunhofer.de>
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 

--- a/ci/lunar-stretch/Dockerfile
+++ b/ci/lunar-stretch/Dockerfile
@@ -1,0 +1,10 @@
+FROM debian:stretch
+
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
+RUN apt-get update -qq     && apt-get -qq install --no-install-recommends -y apt-utils gnupg wget ca-certificates sudo
+
+RUN echo "deb http://packages.ros.org/ros/ubuntu stretch main" > /etc/apt/sources.list.d/ros-latest.list
+RUN apt-key adv --keyserver "hkp://ha.pool.sks-keyservers.net" --recv-key "0xB01FA116"     || { wget "https://raw.githubusercontent.com/ros/rosdistro/master/ros.key" -O - | sudo apt-key add -; }
+
+RUN sed -i "/^# deb.*multiverse/ s/^# //" /etc/apt/sources.list     && apt-get update -qq     && apt-get -qq install --no-install-recommends -y         build-essential         python-catkin-tools         python-pip         python-rosdep         python-wstool         ros-lunar-catkin         ssh-client     && apt-get clean     && rm -rf /var/lib/apt/lists/*

--- a/ci/lunar-stretch/Dockerfile
+++ b/ci/lunar-stretch/Dockerfile
@@ -1,3 +1,6 @@
+# DO NOT EDIT!
+# This file  was auto-generated with ./sync.sh at Fri May 12 16:50:41 CEST 2017
+
 FROM debian:stretch
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections

--- a/ci/lunar-stretch/Dockerfile
+++ b/ci/lunar-stretch/Dockerfile
@@ -1,7 +1,8 @@
 # DO NOT EDIT!
-# This file  was auto-generated with ./sync.sh at Fri May 12 16:50:41 CEST 2017
+# This file  was auto-generated with ./sync.sh at Fri May 12 17:02:13 CEST 2017
 
 FROM debian:stretch
+LABEL MAINTAINER "Mathias Lüdtke" <mathias.luedtke@ipa.fraunhofer.de>
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 

--- a/ci/lunar-xenial-shadow-fixed/Dockerfile
+++ b/ci/lunar-xenial-shadow-fixed/Dockerfile
@@ -1,7 +1,8 @@
 # DO NOT EDIT!
-# This file  was auto-generated with ./sync.sh at Fri May 12 16:50:41 CEST 2017
+# This file  was auto-generated with ./sync.sh at Fri May 12 17:02:13 CEST 2017
 
 FROM ubuntu:xenial
+LABEL MAINTAINER "Mathias Lüdtke" <mathias.luedtke@ipa.fraunhofer.de>
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 

--- a/ci/lunar-xenial-shadow-fixed/Dockerfile
+++ b/ci/lunar-xenial-shadow-fixed/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:xenial
+
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
+RUN apt-get update -qq     && apt-get -qq install --no-install-recommends -y apt-utils gnupg wget ca-certificates sudo
+
+RUN echo "deb http://packages.ros.org/ros/ubuntu xenial main" > /etc/apt/sources.list.d/ros-latest.list
+RUN apt-key adv --keyserver "hkp://ha.pool.sks-keyservers.net" --recv-key "0xB01FA116"     || { wget "https://raw.githubusercontent.com/ros/rosdistro/master/ros.key" -O - | sudo apt-key add -; }
+
+RUN sed -i "/^# deb.*multiverse/ s/^# //" /etc/apt/sources.list     && apt-get update -qq     && apt-get -qq install --no-install-recommends -y         build-essential         python-catkin-tools         python-pip         python-rosdep         python-wstool         ros-lunar-catkin         ssh-client     && apt-get clean     && rm -rf /var/lib/apt/lists/*

--- a/ci/lunar-xenial-shadow-fixed/Dockerfile
+++ b/ci/lunar-xenial-shadow-fixed/Dockerfile
@@ -1,3 +1,6 @@
+# DO NOT EDIT!
+# This file  was auto-generated with ./sync.sh at Fri May 12 16:50:41 CEST 2017
+
 FROM ubuntu:xenial
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections

--- a/ci/lunar-xenial/Dockerfile
+++ b/ci/lunar-xenial/Dockerfile
@@ -1,7 +1,8 @@
 # DO NOT EDIT!
-# This file  was auto-generated with ./sync.sh at Fri May 12 16:50:41 CEST 2017
+# This file  was auto-generated with ./sync.sh at Fri May 12 17:02:13 CEST 2017
 
 FROM ubuntu:xenial
+LABEL MAINTAINER "Mathias Lüdtke" <mathias.luedtke@ipa.fraunhofer.de>
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 

--- a/ci/lunar-xenial/Dockerfile
+++ b/ci/lunar-xenial/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:xenial
+
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
+RUN apt-get update -qq     && apt-get -qq install --no-install-recommends -y apt-utils gnupg wget ca-certificates sudo
+
+RUN echo "deb http://packages.ros.org/ros/ubuntu xenial main" > /etc/apt/sources.list.d/ros-latest.list
+RUN apt-key adv --keyserver "hkp://ha.pool.sks-keyservers.net" --recv-key "0xB01FA116"     || { wget "https://raw.githubusercontent.com/ros/rosdistro/master/ros.key" -O - | sudo apt-key add -; }
+
+RUN sed -i "/^# deb.*multiverse/ s/^# //" /etc/apt/sources.list     && apt-get update -qq     && apt-get -qq install --no-install-recommends -y         build-essential         python-catkin-tools         python-pip         python-rosdep         python-wstool         ros-lunar-catkin         ssh-client     && apt-get clean     && rm -rf /var/lib/apt/lists/*

--- a/ci/lunar-xenial/Dockerfile
+++ b/ci/lunar-xenial/Dockerfile
@@ -1,3 +1,6 @@
+# DO NOT EDIT!
+# This file  was auto-generated with ./sync.sh at Fri May 12 16:50:41 CEST 2017
+
 FROM ubuntu:xenial
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections

--- a/ci/lunar-yakkety-shadow-fixed/Dockerfile
+++ b/ci/lunar-yakkety-shadow-fixed/Dockerfile
@@ -1,7 +1,8 @@
 # DO NOT EDIT!
-# This file  was auto-generated with ./sync.sh at Fri May 12 16:50:41 CEST 2017
+# This file  was auto-generated with ./sync.sh at Fri May 12 17:02:13 CEST 2017
 
 FROM ubuntu:xenial
+LABEL MAINTAINER "Mathias Lüdtke" <mathias.luedtke@ipa.fraunhofer.de>
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 

--- a/ci/lunar-yakkety-shadow-fixed/Dockerfile
+++ b/ci/lunar-yakkety-shadow-fixed/Dockerfile
@@ -1,3 +1,6 @@
+# DO NOT EDIT!
+# This file  was auto-generated with ./sync.sh at Fri May 12 16:50:41 CEST 2017
+
 FROM ubuntu:xenial
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections

--- a/ci/lunar-yakkety-shadow-fixed/Dockerfile
+++ b/ci/lunar-yakkety-shadow-fixed/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:xenial
+
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
+RUN apt-get update -qq     && apt-get -qq install --no-install-recommends -y apt-utils gnupg wget ca-certificates sudo
+
+RUN echo "deb http://packages.ros.org/ros/ubuntu yakkety main" > /etc/apt/sources.list.d/ros-latest.list
+RUN apt-key adv --keyserver "hkp://ha.pool.sks-keyservers.net" --recv-key "0xB01FA116"     || { wget "https://raw.githubusercontent.com/ros/rosdistro/master/ros.key" -O - | sudo apt-key add -; }
+
+RUN sed -i "/^# deb.*multiverse/ s/^# //" /etc/apt/sources.list     && apt-get update -qq     && apt-get -qq install --no-install-recommends -y         build-essential         python-catkin-tools         python-pip         python-rosdep         python-wstool         ros-lunar-catkin         ssh-client     && apt-get clean     && rm -rf /var/lib/apt/lists/*

--- a/ci/lunar-yakkety/Dockerfile
+++ b/ci/lunar-yakkety/Dockerfile
@@ -1,7 +1,8 @@
 # DO NOT EDIT!
-# This file  was auto-generated with ./sync.sh at Fri May 12 16:50:41 CEST 2017
+# This file  was auto-generated with ./sync.sh at Fri May 12 17:02:13 CEST 2017
 
 FROM ubuntu:xenial
+LABEL MAINTAINER "Mathias Lüdtke" <mathias.luedtke@ipa.fraunhofer.de>
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 

--- a/ci/lunar-yakkety/Dockerfile
+++ b/ci/lunar-yakkety/Dockerfile
@@ -1,3 +1,6 @@
+# DO NOT EDIT!
+# This file  was auto-generated with ./sync.sh at Fri May 12 16:50:41 CEST 2017
+
 FROM ubuntu:xenial
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections

--- a/ci/lunar-yakkety/Dockerfile
+++ b/ci/lunar-yakkety/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:xenial
+
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
+RUN apt-get update -qq     && apt-get -qq install --no-install-recommends -y apt-utils gnupg wget ca-certificates sudo
+
+RUN echo "deb http://packages.ros.org/ros/ubuntu yakkety main" > /etc/apt/sources.list.d/ros-latest.list
+RUN apt-key adv --keyserver "hkp://ha.pool.sks-keyservers.net" --recv-key "0xB01FA116"     || { wget "https://raw.githubusercontent.com/ros/rosdistro/master/ros.key" -O - | sudo apt-key add -; }
+
+RUN sed -i "/^# deb.*multiverse/ s/^# //" /etc/apt/sources.list     && apt-get update -qq     && apt-get -qq install --no-install-recommends -y         build-essential         python-catkin-tools         python-pip         python-rosdep         python-wstool         ros-lunar-catkin         ssh-client     && apt-get clean     && rm -rf /var/lib/apt/lists/*

--- a/ci/lunar-zesty-shadow-fixed/Dockerfile
+++ b/ci/lunar-zesty-shadow-fixed/Dockerfile
@@ -1,7 +1,8 @@
 # DO NOT EDIT!
-# This file  was auto-generated with ./sync.sh at Fri May 12 16:50:41 CEST 2017
+# This file  was auto-generated with ./sync.sh at Fri May 12 17:02:13 CEST 2017
 
 FROM ubuntu:xenial
+LABEL MAINTAINER "Mathias Lüdtke" <mathias.luedtke@ipa.fraunhofer.de>
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 

--- a/ci/lunar-zesty-shadow-fixed/Dockerfile
+++ b/ci/lunar-zesty-shadow-fixed/Dockerfile
@@ -1,3 +1,6 @@
+# DO NOT EDIT!
+# This file  was auto-generated with ./sync.sh at Fri May 12 16:50:41 CEST 2017
+
 FROM ubuntu:xenial
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections

--- a/ci/lunar-zesty-shadow-fixed/Dockerfile
+++ b/ci/lunar-zesty-shadow-fixed/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:xenial
+
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
+RUN apt-get update -qq     && apt-get -qq install --no-install-recommends -y apt-utils gnupg wget ca-certificates sudo
+
+RUN echo "deb http://packages.ros.org/ros/ubuntu zesty main" > /etc/apt/sources.list.d/ros-latest.list
+RUN apt-key adv --keyserver "hkp://ha.pool.sks-keyservers.net" --recv-key "0xB01FA116"     || { wget "https://raw.githubusercontent.com/ros/rosdistro/master/ros.key" -O - | sudo apt-key add -; }
+
+RUN sed -i "/^# deb.*multiverse/ s/^# //" /etc/apt/sources.list     && apt-get update -qq     && apt-get -qq install --no-install-recommends -y         build-essential         python-catkin-tools         python-pip         python-rosdep         python-wstool         ros-lunar-catkin         ssh-client     && apt-get clean     && rm -rf /var/lib/apt/lists/*

--- a/ci/lunar-zesty/Dockerfile
+++ b/ci/lunar-zesty/Dockerfile
@@ -1,7 +1,8 @@
 # DO NOT EDIT!
-# This file  was auto-generated with ./sync.sh at Fri May 12 16:50:41 CEST 2017
+# This file  was auto-generated with ./sync.sh at Fri May 12 17:02:13 CEST 2017
 
 FROM ubuntu:xenial
+LABEL MAINTAINER "Mathias Lüdtke" <mathias.luedtke@ipa.fraunhofer.de>
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 

--- a/ci/lunar-zesty/Dockerfile
+++ b/ci/lunar-zesty/Dockerfile
@@ -1,3 +1,6 @@
+# DO NOT EDIT!
+# This file  was auto-generated with ./sync.sh at Fri May 12 16:50:41 CEST 2017
+
 FROM ubuntu:xenial
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections

--- a/ci/lunar-zesty/Dockerfile
+++ b/ci/lunar-zesty/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:xenial
+
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
+RUN apt-get update -qq     && apt-get -qq install --no-install-recommends -y apt-utils gnupg wget ca-certificates sudo
+
+RUN echo "deb http://packages.ros.org/ros/ubuntu zesty main" > /etc/apt/sources.list.d/ros-latest.list
+RUN apt-key adv --keyserver "hkp://ha.pool.sks-keyservers.net" --recv-key "0xB01FA116"     || { wget "https://raw.githubusercontent.com/ros/rosdistro/master/ros.key" -O - | sudo apt-key add -; }
+
+RUN sed -i "/^# deb.*multiverse/ s/^# //" /etc/apt/sources.list     && apt-get update -qq     && apt-get -qq install --no-install-recommends -y         build-essential         python-catkin-tools         python-pip         python-rosdep         python-wstool         ros-lunar-catkin         ssh-client     && apt-get clean     && rm -rf /var/lib/apt/lists/*

--- a/ci/sync.sh
+++ b/ci/sync.sh
@@ -8,6 +8,7 @@ source $DIR_ICI/src/docker.sh
 
 DIR_THIS="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 HEADER="# DO NOT EDIT!\n# This file  was auto-generated with ./sync.sh at $(LC_ALL=C date)\n"
+INJECT_MAINTAINER="/^FROM/a LABEL MAINTAINER \"$(git config --get user.name)\" <$(git config --get user.email)>"
 
 function export_dockerfile {
     ROS_DISTRO=$1
@@ -24,7 +25,7 @@ function export_dockerfile {
     mkdir -p "$path"
 
     echo -e "$HEADER" > $path/Dockerfile
-    ici_generate_default_dockerfile >> $path/Dockerfile
+    ici_generate_default_dockerfile | sed "$INJECT_MAINTAINER" >> $path/Dockerfile
 }
 
 for r in ros ros-shadow-fixed; do

--- a/ci/sync.sh
+++ b/ci/sync.sh
@@ -7,6 +7,7 @@ source $DIR_ICI/src/util.sh
 source $DIR_ICI/src/docker.sh
 
 DIR_THIS="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+HEADER="# DO NOT EDIT!\n# This file  was auto-generated with ./sync.sh at $(LC_ALL=C date)\n"
 
 function export_dockerfile {
     ROS_DISTRO=$1
@@ -22,9 +23,9 @@ function export_dockerfile {
     local path=$DIR_THIS/$ROS_DISTRO-${5:-$OS_CODE_NAME}${ROS_REPO#ros}
     mkdir -p "$path"
 
-    ici_generate_default_dockerfile > $path/Dockerfile
+    echo -e "$HEADER" > $path/Dockerfile
+    ici_generate_default_dockerfile >> $path/Dockerfile
 }
-
 
 for r in ros ros-shadow-fixed; do
     for d in hydro indigo jade kinetic lunar; do

--- a/ci/sync.sh
+++ b/ci/sync.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -e
+
+DIR_ICI=$(rospack find industrial_ci)
+source $DIR_ICI/src/util.sh
+source $DIR_ICI/src/docker.sh
+
+DIR_THIS="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+function export_dockerfile {
+    ROS_DISTRO=$1
+    ROS_REPO=$2
+    UBUNTU_OS_CODE_NAME=
+    OS_CODE_NAME=
+    DOCKER_BASE_IMAGE=
+
+    source $DIR_ICI/src/env.sh
+    OS_CODE_NAME=${3:-$OS_CODE_NAME}
+    DOCKER_BASE_IMAGE=${4:-$DOCKER_BASE_IMAGE}
+
+    local path=$DIR_THIS/$ROS_DISTRO-${5:-$OS_CODE_NAME}${ROS_REPO#ros}
+    mkdir -p "$path"
+
+    ici_generate_default_dockerfile > $path/Dockerfile
+}
+
+
+for r in ros ros-shadow-fixed; do
+    for d in hydro indigo jade kinetic lunar; do
+        export_dockerfile $d $r
+    done
+    export_dockerfile kinetic $r jessie debian:jessie
+    export_dockerfile lunar $r yakkety
+    export_dockerfile lunar $r zesty
+    export_dockerfile lunar $r stretch debian:stretch
+done
+


### PR DESCRIPTION
This PR adds auto-generated Dockerfiles for `industrial_ci` for all supported ROS distros and Debian-based OSes in regular and `shadow-fixed` variants.

The sync script needs `industrial_ci` in a sourced catkin workspace, with patches from https://github.com/ros-industrial/industrial_ci/pull/174


