### PR TITLE
Add caffe &  nvidia-docker support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # docker
-ROS-Industrial container tools
+ROS-Industrial container tools.
+
+## caffe-cpu
+[BVLC's caffe image](https://github.com/BVLC/caffe) built ontop of the rosindustrial/core image.
+
+## caffe-gpu
+[BVLC's caffe image](https://github.com/BVLC/caffe) built ontop of the rosindustrial/core image. contains both gpu and cpu versions.
+
+## ci
+Continuous Integration Dockerfiles for ros-industrial environments
 
 ## core
 core docker is the root container for all others.
@@ -8,5 +17,20 @@ core docker is the root container for all others.
 ros-bridge-suite and all packages nessesary to run robotwebtools
 
 ## noether
-PCL 1.8 build on VTK 7.1.
+PCL 1.8 built with VTK 7.1.
+
+## ros-core-nvidia
+osrf [ros-core image](https://hub.docker.com/_/ros/) built ontop of Nvidia's [cuda ubuntu image](https://hub.docker.com/r/nvidia/cuda/).
+
+## ros-base-nvidia
+osrf [ros-base image](https://hub.docker.com/_/ros/) built ontop of rosindstrial/ros-core-nvidia.
+
+## ros-robot-nvidia
+osrf [ros-robot image](https://hub.docker.com/_/ros/) built ontop of rosindstrial/ros-base-nvidia.
+
+## core-nvidia
+rosindustrial/core iamge built ontop of rosindstrial/ros-robot-nvidia.
+
+
+
 

--- a/a5/Dockerfile
+++ b/a5/Dockerfile
@@ -1,6 +1,6 @@
 # rosindustrial/a5:kinetic
 FROM rosindustrial/noether:kinetic
-LABEL maintainer "Austin.Deric@gmail.com"
+LABEL maintainer "Austin.Deric@swri.org"
 RUN apt-get update && apt-get install -y --no-install-recommends \
   ros-kinetic-stage && \
   apt-get clean && \

--- a/caffe/cpu/indigo/Dockerfile
+++ b/caffe/cpu/indigo/Dockerfile
@@ -1,0 +1,47 @@
+FROM rosindustrial/core:indigo
+LABEL maintainer "alexgoins301<at>gmail<dot>com"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        cmake \
+        git \
+        wget \
+        libatlas-base-dev \
+        libboost-all-dev \
+        libgflags-dev \
+        libgoogle-glog-dev \
+        libhdf5-serial-dev \
+        libleveldb-dev \
+        liblmdb-dev \
+        libopencv-dev \
+        libprotobuf-dev \
+        libsnappy-dev \
+        protobuf-compiler \
+        python-dev \
+        python-numpy \
+        python-pip \
+        python-setuptools \
+        python-scipy && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV CAFFE_ROOT=/opt/caffe
+WORKDIR $CAFFE_ROOT
+
+# FIXME: use ARG instead of ENV once DockerHub supports this
+# https://github.com/docker/hub-feedback/issues/460
+ENV CLONE_TAG=master
+#1.0
+
+RUN git clone -b ${CLONE_TAG} --depth 1 https://github.com/BVLC/caffe.git . && \
+    pip install --upgrade pip && \
+    cd python && for req in $(cat requirements.txt) pydot; do pip install $req; done && cd .. && \
+    mkdir build && cd build && \
+    cmake -DCPU_ONLY=1 .. && \
+    make -j"$(nproc)"
+
+ENV PYCAFFE_ROOT $CAFFE_ROOT/python
+ENV PYTHONPATH $PYCAFFE_ROOT:$PYTHONPATH
+ENV PATH $CAFFE_ROOT/build/tools:$PYCAFFE_ROOT:$PATH
+RUN echo "$CAFFE_ROOT/build/lib" >> /etc/ld.so.conf.d/caffe.conf && ldconfig
+
+WORKDIR /workspace

--- a/caffe/cpu/kinetic/Dockerfile
+++ b/caffe/cpu/kinetic/Dockerfile
@@ -1,5 +1,5 @@
-FROM rosindustrial/core:indigo
-LABEL maintainer alexgoins301<at>gmail<dot>com
+FROM rosindustrial/core:kinetic
+LABEL maintainer "alexgoins301<at>gmail<dot>com"
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
@@ -29,8 +29,8 @@ WORKDIR $CAFFE_ROOT
 
 # FIXME: use ARG instead of ENV once DockerHub supports this
 # https://github.com/docker/hub-feedback/issues/460
-ENV CLONE_TAG=master
-#1.0
+ENV CLONE_TAG=1.0
+
 
 RUN git clone -b ${CLONE_TAG} --depth 1 https://github.com/BVLC/caffe.git . && \
     pip install --upgrade pip && \

--- a/caffe/gpu/indigo/Dockerfile
+++ b/caffe/gpu/indigo/Dockerfile
@@ -1,5 +1,6 @@
-FROM rosindustrial/core:kinetic
-LABEL maintainer alexgoins301<at>gmail<dot>com
+# nvidia-docker build -t rosindustrial/caffe-gpu:indigo .
+FROM rosindustrial/core-nvidia:indigo
+LABEL maintainer "Austin.Deric@swri.org"
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
@@ -29,14 +30,14 @@ WORKDIR $CAFFE_ROOT
 
 # FIXME: use ARG instead of ENV once DockerHub supports this
 # https://github.com/docker/hub-feedback/issues/460
-ENV CLONE_TAG=1.0
-
+ENV CLONE_TAG=master
 
 RUN git clone -b ${CLONE_TAG} --depth 1 https://github.com/BVLC/caffe.git . && \
     pip install --upgrade pip && \
     cd python && for req in $(cat requirements.txt) pydot; do pip install $req; done && cd .. && \
+    git clone https://github.com/NVIDIA/nccl.git && cd nccl && make -j install && cd .. && rm -rf nccl && \
     mkdir build && cd build && \
-    cmake -DCPU_ONLY=1 .. && \
+    cmake -DUSE_CUDNN=1 -DUSE_NCCL=1 .. && \
     make -j"$(nproc)"
 
 ENV PYCAFFE_ROOT $CAFFE_ROOT/python

--- a/caffe/gpu/kinetic/Dockerfile
+++ b/caffe/gpu/kinetic/Dockerfile
@@ -1,0 +1,47 @@
+FROM rosindustrial/core-nvidia:kinetic
+LABEL maintainer "Austin.Deric@SwRI.org"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        cmake \
+        git \
+        wget \
+        libatlas-base-dev \
+        libboost-all-dev \
+        libgflags-dev \
+        libgoogle-glog-dev \
+        libhdf5-serial-dev \
+        libleveldb-dev \
+        liblmdb-dev \
+        libopencv-dev \
+        libprotobuf-dev \
+        libsnappy-dev \
+        protobuf-compiler \
+        python-dev \
+        python-numpy \
+        python-pip \
+        python-setuptools \
+        python-scipy && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV CAFFE_ROOT=/opt/caffe
+WORKDIR $CAFFE_ROOT
+
+# FIXME: use ARG instead of ENV once DockerHub supports this
+# https://github.com/docker/hub-feedback/issues/460
+ENV CLONE_TAG=1.0
+
+RUN git clone -b ${CLONE_TAG} --depth 1 https://github.com/BVLC/caffe.git . && \
+    pip install --upgrade pip && \
+    cd python && for req in $(cat requirements.txt) pydot; do pip install $req; done && cd .. && \
+    git clone https://github.com/NVIDIA/nccl.git && cd nccl && make -j install && cd .. && rm -rf nccl && \
+    mkdir build && cd build && \
+    cmake -DUSE_CUDNN=1 -DUSE_NCCL=1 .. && \
+    make -j"$(nproc)"
+
+ENV PYCAFFE_ROOT $CAFFE_ROOT/python
+ENV PYTHONPATH $PYCAFFE_ROOT:$PYTHONPATH
+ENV PATH $CAFFE_ROOT/build/tools:$PYCAFFE_ROOT:$PATH
+RUN echo "$CAFFE_ROOT/build/lib" >> /etc/ld.so.conf.d/caffe.conf && ldconfig
+
+WORKDIR /workspace

--- a/core-nvidia/indigo/Dockerfile
+++ b/core-nvidia/indigo/Dockerfile
@@ -1,9 +1,9 @@
-# rosindustrial/core:kinetic
-FROM ros:kinetic-robot
-LABEL maintainer "Austin.Deric@swri.org"
+# nvidia-docker build -t rosindustrial/core-nvidia:indigo .
+FROM rosindustrial/ros-robot-nvidia:indigo
+LABEL maintainer "Austin.Deric@SwRI.org"
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ros-kinetic-industrial-core \
+    ros-indigo-industrial-core \
     python-wstool \
     python-catkin-tools \
     liblapack-dev \

--- a/core-nvidia/kinetic/Dockerfile
+++ b/core-nvidia/kinetic/Dockerfile
@@ -1,6 +1,6 @@
-# rosindustrial/core:kinetic
-FROM ros:kinetic-robot
-LABEL maintainer "Austin.Deric@swri.org"
+# rosindustrial/core-nvidia:kinetic
+FROM rosindustrial/ros-robot-nvidia:kinetic
+LABEL maintainer "Austin.Deric@SwRI.org"
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-kinetic-industrial-core \

--- a/core/indigo/Dockerfile
+++ b/core/indigo/Dockerfile
@@ -1,6 +1,7 @@
 # rosindustrial/core:indigo
 FROM ros:indigo-robot
-LABEL maintainer "Austin.Deric@gmail.com"
+LABEL maintainer "Austin.Deric@swri.org"
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-indigo-industrial-core \
     python-wstool \

--- a/noether-webtools/Dockerfile
+++ b/noether-webtools/Dockerfile
@@ -1,6 +1,7 @@
 # rosindustrial/noether-webtools:kinetic
 FROM rosindustrial/noether:kinetic
-LABEL maintainer "Austin.Deric@gmail.com"
+LABEL maintainer "Austin.Deric@SwRI.org"
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
   ros-kinetic-rosbridge-suite \
   ros-kinetic-tf2-web-republisher && \

--- a/noether/Dockerfile
+++ b/noether/Dockerfile
@@ -1,6 +1,7 @@
 # rosindustrial/noether:kinetic
 FROM rosindustrial/core:kinetic
-LABEL maintainer "Austin.Deric@gmail.com"
+LABEL maintainer "Austin.Deric@SwRI.org"
+
 COPY setup_script.bash /
 RUN bash -c "chmod +x /setup_script.bash && /setup_script.bash"
 RUN apt-get clean && \

--- a/ros-base-nvidia/indigo/Dockerfile
+++ b/ros-base-nvidia/indigo/Dockerfile
@@ -1,0 +1,7 @@
+# nvidia-docker build -t rosindustrial/ros-base-nvidia:indigo .
+FROM rosindustrial/ros-core-nvidia:indigo
+LABEL maintainer "Austin.Deric@SwRI.org"
+
+RUN apt-get update && apt-get install -y \
+    ros-indigo-ros-base=1.1.5-0* \
+&& rm -rf /var/lib/apt/lists/*

--- a/ros-base-nvidia/kinetic/Dockerfile
+++ b/ros-base-nvidia/kinetic/Dockerfile
@@ -1,0 +1,7 @@
+# nvidia-docker build -t rosindustrial/ros-base-nvidia:kinetic .
+FROM rosindustrial/ros-core-nvidia:kinetic
+LABEL maintainer "Austin.Deric@SwRI.org"
+
+RUN apt-get update && apt-get install -y \
+    ros-kinetic-ros-base=1.3.1-0* \
+&& rm -rf /var/lib/apt/lists/*

--- a/ros-base-nvidia/lunar/Dockerfile
+++ b/ros-base-nvidia/lunar/Dockerfile
@@ -1,0 +1,7 @@
+# nvidia-docker build -t rosindustrial/ros-base-nvidia:lunar .
+FROM rosindustrial/ros-core-nvidia:lunar
+LABEL maintainer "Austin.Deric@SwRI.org"
+
+RUN apt-get update && apt-get install -y \
+    ros-lunar-ros-base=1.3.1-0* \
+&& rm -rf /var/lib/apt/lists/*

--- a/ros-core-nvidia/indigo/Dockerfile
+++ b/ros-core-nvidia/indigo/Dockerfile
@@ -1,0 +1,36 @@
+# nvidia-docker build -t rosindustrial/ros-core-nvidia:indigo .
+FROM nvidia/cuda:8.0-devel-ubuntu14.04
+LABEL maintainer "Austin.Deric@SwRI.org"
+
+# setup keys
+RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+
+# setup sources.list
+RUN echo "deb http://packages.ros.org/ros/ubuntu trusty main" > /etc/apt/sources.list.d/ros-latest.list
+
+# install bootstrap tools
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    python-rosdep \
+    python-rosinstall \
+    python-vcstools \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup environment
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+
+# bootstrap rosdep
+RUN rosdep init \
+    && rosdep update
+
+# install ros packages
+ENV ROS_DISTRO indigo
+RUN apt-get update && apt-get install -y \
+    ros-indigo-ros-core=1.1.5-0* \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup entrypoint
+COPY ./ros_entrypoint.sh /
+
+ENTRYPOINT ["/ros_entrypoint.sh"]
+CMD ["bash"]

--- a/ros-core-nvidia/indigo/ros_entrypoint.sh
+++ b/ros-core-nvidia/indigo/ros_entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+# setup ros environment
+source "/opt/ros/$ROS_DISTRO/setup.bash"
+exec "$@"

--- a/ros-core-nvidia/kinetic/Dockerfile
+++ b/ros-core-nvidia/kinetic/Dockerfile
@@ -1,0 +1,36 @@
+# nvidia-docker build -t rosindustrial/ros-core-nvidia:kinetic .
+FROM nvidia/cuda:8.0-devel-ubuntu16.04
+LABEL maintainer "Austin.Deric@SwRI.org"
+
+# setup keys
+RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+
+# setup sources.list
+RUN echo "deb http://packages.ros.org/ros/ubuntu xenial main" > /etc/apt/sources.list.d/ros-latest.list
+
+# install bootstrap tools
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    python-rosdep \
+    python-rosinstall \
+    python-vcstools \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup environment
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+
+# bootstrap rosdep
+RUN rosdep init \
+    && rosdep update
+
+# install ros packages
+ENV ROS_DISTRO kinetic
+RUN apt-get update && apt-get install -y \
+    ros-kinetic-ros-core=1.3.1-0* \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup entrypoint
+COPY ./ros_entrypoint.sh /
+
+ENTRYPOINT ["/ros_entrypoint.sh"]
+CMD ["bash"]

--- a/ros-core-nvidia/kinetic/ros_entrypoint.sh
+++ b/ros-core-nvidia/kinetic/ros_entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+# setup ros environment
+source "/opt/ros/$ROS_DISTRO/setup.bash"
+exec "$@"

--- a/ros-core-nvidia/lunar/Dockerfile
+++ b/ros-core-nvidia/lunar/Dockerfile
@@ -1,0 +1,37 @@
+# nvidia-docker build -t rosindustrial/ros-core-nvidia:lunar .
+FROM nvidia/cuda:8.0-devel-ubuntu16.04
+LABEL maintainer "Austin.Deric@SwRI.org"
+
+# setup keys
+RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+
+# setup sources.list
+RUN echo "deb http://packages.ros.org/ros/ubuntu xenial main" > /etc/apt/sources.list.d/ros-latest.list
+
+# install bootstrap tools
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    python-rosdep \
+    python-rosinstall \
+    python-vcstools \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup environment
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+
+# bootstrap rosdep
+RUN rosdep init \
+    && rosdep update
+
+# install ros packages
+ENV ROS_DISTRO lunar
+RUN apt-get update && apt-get install -y \
+    ros-lunar-ros-core=1.3.1-0* \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup entrypoint
+COPY ./ros_entrypoint.sh /
+
+ENTRYPOINT ["/ros_entrypoint.sh"]
+CMD ["bash"]
+

--- a/ros-core-nvidia/lunar/ros_entrypoint.sh
+++ b/ros-core-nvidia/lunar/ros_entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+# setup ros environment
+source "/opt/ros/$ROS_DISTRO/setup.bash"
+exec "$@"

--- a/ros-robot-nvidia/indigo/Dockerfile
+++ b/ros-robot-nvidia/indigo/Dockerfile
@@ -1,0 +1,7 @@
+# nvidia-docker build -t rosindustrial/ros-robot-nvidia:indigo .
+FROM rosindustrial/ros-base-nvidia:indigo
+LABEL maintainer "Austin.Deric@SwRI.org"
+
+RUN apt-get update && apt-get install -y \
+    ros-indigo-robot=1.1.5-0* \
+&& rm -rf /var/lib/apt/lists/*

--- a/ros-robot-nvidia/kinetic/Dockerfile
+++ b/ros-robot-nvidia/kinetic/Dockerfile
@@ -1,0 +1,7 @@
+# nvidia-docker build -t rosindustrial/ros-robot-nvidia:kinetic .
+FROM rosindustrial/ros-base-nvidia:kinetic
+LABEL maintainer "Austin.Deric@SwRI.org"
+
+RUN apt-get update && apt-get install -y \
+    ros-kinetic-robot=1.3.1-0* \
+&& rm -rf /var/lib/apt/lists/*

--- a/ros-robot-nvidia/lunar/Dockerfile
+++ b/ros-robot-nvidia/lunar/Dockerfile
@@ -1,0 +1,7 @@
+# nvidia-docker build -t rosindustrial/ros-robot-nvidia:lunar .
+FROM rosindustrial/ros-base-nvidia:lunar
+LABEL maintainer "Austin.Deric@SwRI.org"
+
+RUN apt-get update && apt-get install -y \
+    ros-lunar-robot=1.3.1-0* \
+&& rm -rf /var/lib/apt/lists/*

--- a/viz/Dockerfile
+++ b/viz/Dockerfile
@@ -1,6 +1,7 @@
 # rosindustrial/viz:kinetic
 FROM rosindustrial/webtools:kinetic
-LABEL maintainer "Austin.Deric@gmail.com"
+LABEL maintainer "Austin.Deric@SwRI.org"
+
 RUN mkdir -p /workspace/src
 COPY viz.launch /
 

--- a/webtools/Dockerfile
+++ b/webtools/Dockerfile
@@ -1,6 +1,7 @@
 # rosindustrial/webtools:kinetic
 FROM rosindustrial/core:kinetic
-LABEL maintainer "Austin.Deric@gmail.com"
+LABEL maintainer "Austin.Deric@SwRI.org"
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
   ros-kinetic-rosbridge-suite \
   ros-kinetic-tf2-web-republisher && \


### PR DESCRIPTION
I pushed images to the docker repository so they can be evaluated:

https://hub.docker.com/r/rosindustrial/ros-core-nvidia/
https://hub.docker.com/r/rosindustrial/ros-base-nvidia/
https://hub.docker.com/r/rosindustrial/ros-robot-nvidia/
https://hub.docker.com/r/rosindustrial/core-nvidia/
https://hub.docker.com/r/rosindustrial/caffe-gpu/

This will help with our artificial intelligence and deformable material efforts.  Does anyone have any ideas for naming conventions?  Right now i am changing the image name for different layers and keeping the tag strictly related to ROS releases.

Thanks,
-Austin
