### PR TITLE
remove application specific docker files and add travis badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: generic
 
 env:
   - REPOS="ci"
-  - REPOS="core/kinetic caffe/cpu/kinetic webtools viz noether noether-webtools a5" DEFAULT_TAG=kinetic
+  - REPOS="core/kinetic caffe/cpu/kinetic noether" DEFAULT_TAG=kinetic
   - REPOS="core/indigo caffe/cpu/indigo"
   - REPOS="ros-core-nvidia/kinetic ros-base-nvidia/kinetic ros-robot-nvidia/kinetic core-nvidia/kinetic caffe/gpu/kinetic"
   - REPOS="ros-core-nvidia/indigo ros-base-nvidia/indigo ros-robot-nvidia/indigo core-nvidia/indigo caffe/gpu/indigo"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # docker
 ROS-Industrial container tools.
 
+[![Build Status](https://travis-ci.org/ros-industrial/docker.svg?branch=master)](https://travis-ci.org/ros-industrial/docker)
+
 ## caffe-cpu
 [BVLC's caffe image](https://github.com/BVLC/caffe) built ontop of the rosindustrial/core image.
 
@@ -12,9 +14,6 @@ Continuous Integration Dockerfiles for ros-industrial environments
 
 ## core
 core docker is the root container for all others.
-
-## webtools
-ros-bridge-suite and all packages nessesary to run robotwebtools
 
 ## noether
 PCL 1.8 built with VTK 7.1.

--- a/a5/Dockerfile
+++ b/a5/Dockerfile
@@ -1,7 +1,0 @@
-# rosindustrial/a5:kinetic
-FROM rosindustrial/noether:kinetic
-LABEL maintainer "Austin.Deric@swri.org"
-RUN apt-get update && apt-get install -y --no-install-recommends \
-  ros-kinetic-stage && \
-  apt-get clean && \
-  rm -rf /var/lib/apt/lists/*

--- a/noether-webtools/Dockerfile
+++ b/noether-webtools/Dockerfile
@@ -1,9 +1,0 @@
-# rosindustrial/noether-webtools:kinetic
-FROM rosindustrial/noether:kinetic
-LABEL maintainer "Austin.Deric@SwRI.org"
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-  ros-kinetic-rosbridge-suite \
-  ros-kinetic-tf2-web-republisher && \
-  apt-get clean && \
-  rm -rf /var/lib/apt/lists/*

--- a/viz/Dockerfile
+++ b/viz/Dockerfile
@@ -1,7 +1,0 @@
-# rosindustrial/viz:kinetic
-FROM rosindustrial/webtools:kinetic
-LABEL maintainer "Austin.Deric@SwRI.org"
-
-RUN mkdir -p /workspace/src
-COPY viz.launch /
-

--- a/viz/viz.launch
+++ b/viz/viz.launch
@@ -1,7 +1,0 @@
-<launch>
-    <include file="$(find rosbridge_server)/launch/rosbridge_websocket.launch" />
-    <node name="tf2_web_republisher" pkg="tf2_web_republisher" type="tf2_web_republisher"/>		     
-  	<node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
-  	<node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
-  	</node>
-</launch>

--- a/webtools/Dockerfile
+++ b/webtools/Dockerfile
@@ -1,9 +1,0 @@
-# rosindustrial/webtools:kinetic
-FROM rosindustrial/core:kinetic
-LABEL maintainer "Austin.Deric@SwRI.org"
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-  ros-kinetic-rosbridge-suite \
-  ros-kinetic-tf2-web-republisher && \
-  apt-get clean && \
-  rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Removes application specific dockerfiles for the following projects. These were included because of an accident of history. i had originally included my entire ros-industrial docker folder in the initial commit and not all of those docker files are relevant to the community.  furthermore, it is good practice it to separate services and run them as separate containers with a docker-compose.  I will include this in an example in a future PR.

I also included the travis badge in the readme.

The build is passing (https://travis-ci.org/AustinDeric/docker/builds/383771416), i am working with @Levi-Armstrong to get travis turned on for this repo.