### PR TITLE
add ros-desktop-full nvidia Dockerfile.

### DIFF
--- a/ros-desktop-full/kinetic-nvidia9.2/Dockerfile
+++ b/ros-desktop-full/kinetic-nvidia9.2/Dockerfile
@@ -1,0 +1,30 @@
+# nvidia-docker build -t rosindustrial/ros-desktop-full:kinetic-nvidia9.2 .
+FROM nvidia/cuda:9.2-devel-ubuntu16.04
+LABEL maintainer "Austin.Deric@gmail.org"
+
+# Setup your sources.list
+RUN sh -c 'echo "deb http://packages.ros.org/ros/ubuntu xenial main" > /etc/apt/sources.list.d/ros-latest.list'
+
+# Set up your keys
+RUN apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
+
+# Installation
+
+RUN apt-get update && apt-get install -y \
+    ros-kinetic-desktop-full \
+    && rm -rf /var/lib/apt/lists/*
+
+# Initialize rosdep
+RUN rosdep init
+RUN rosdep update
+
+
+RUN echo "source /opt/ros/kinetic/setup.bash" >> ~/.bashrc
+
+RUN apt-get update && apt-get install -y \
+    python-rosinstall \
+    python-rosinstall-generator \
+    python-wstool \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/ros-desktop-full/kinetic-nvidia9.2/run.bash
+++ b/ros-desktop-full/kinetic-nvidia9.2/run.bash
@@ -1,0 +1,22 @@
+XAUTH=/tmp/.docker.xauth
+if [ ! -f $XAUTH ]
+then
+    xauth_list=$(xauth nlist :0 | sed -e 's/^..../ffff/')
+    if [ ! -z "$xauth_list" ]
+    then
+        echo $xauth_list | xauth -f $XAUTH nmerge -
+    else
+        touch $XAUTH
+    fi
+    chmod a+r $XAUTH
+fi
+
+docker run -it \
+    --env="DISPLAY" \
+    --env="QT_X11_NO_MITSHM=1" \
+    --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" \
+    -env="XAUTHORITY=$XAUTH" \
+    --volume="$XAUTH:$XAUTH" \
+    --runtime=nvidia \
+    rosindustrial/ros-desktop-full:latest \
+    /bin/bash


### PR DESCRIPTION
for use using the docker-nvidia2 method:
http://wiki.ros.org/docker/Tutorials/Hardware%20Acceleration

I consider these temporary because OSRF should support nvidia ros images. Therefore, I am working with OSRF to support the ros nvidia docker images.