### PR TITLE
Provide build for tesseract_ros and dependencies

### DIFF
--- a/tesseract-ros/Dockerfile
+++ b/tesseract-ros/Dockerfile
@@ -1,0 +1,38 @@
+ARG ROSDISTRO=noetic
+ARG ROS_BASE_TAG=noetic
+
+FROM ros:$ROS_BASE_TAG
+MAINTAINER Levi Armstrong
+
+ARG ROSDISTRO
+ARG DEBIAN_FRONTEND=noninteractive
+ARG TESSERACT_ROS_VERSION=master
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    git \
+    python3-colcon-common-extensions \
+    python3-vcstool \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /
+RUN mkdir -p /tesseract/src \
+  && cd /tesseract/src \
+  && git clone --depth 1 --branch $TESSERACT_ROS_VERSION \
+       https://github.com/ros-industrial-consortium/tesseract_ros.git \
+  && vcs import --shallow --input tesseract_ros/dependencies.rosinstall . \
+  && apt-get update \
+  && rosdep install --rosdistro $ROSDISTRO -y --ignore-src --from-paths . \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* \
+  && cd / \
+  && . /opt/ros/$ROSDISTRO/setup.sh \
+  && colcon build \
+  --base-paths /tesseract/src \
+  --build-base /tesseract/build \
+  --install-base /opt/tesseract \
+  --merge-install \
+  --event-handlers status- console_cohesion+ \
+  --cmake-args -DCMAKE_BUILD_TYPE=Release \
+  && rm -rf /tesseract


### PR DESCRIPTION
I saw there wasn't a way to build an image that contains a source build of tesseract for use in applications. This enables building an image from the tesseract_ros repo and all its dependencies, including tesseract, tesseract_planning, etc. The image contains a built underlay workspace in `/opt/tesseract` which can be used by downstream applications instead of `/opt/ros/noetic`.

@Levi-Armstrong, I'd be interested to get your feedback if this is useful for this repo and what changes/improvements you think could be made. 